### PR TITLE
880 report ignores |0 additions

### DIFF
--- a/lib/authority_control_utilities/changed_880.rb
+++ b/lib/authority_control_utilities/changed_880.rb
@@ -11,8 +11,33 @@ class Changed880
     true if lines.find { |line| line.match(/^[-+]880/) }
   end
 
+  # The marcive report indicates original fields with a leading "+" and
+  # changed fields with a leading "-", but we expect and rely on a sequence of:
+  #   initial/bnum line, original field, changed field, [vernacular field/880]
+
+  # the original non-vernacular existing/changed field
+  def original_field
+    lines[1]
+  end
+
+  # the new/changed non-vernacular field
+  def changed_field
+    lines[2]
+  end
+
+  def ignorable_changes?
+    # - discard leading -/+ indicating original/changed fields
+    # - ignore $0 contents
+    #     per RDM/DMS, we ignore cases where marcive adds an $0, and marcive
+    #     will never remove/edit an existing $0. So we do not need to remove
+    #     the $0 from the original field; we know all of these fields changed
+    #     and that changes cannot happen inside existing $0's.
+    original_field[1..-1] == changed_field[1..-1].gsub(/\$0[^$]*/, '')
+  end
+
   def write
     return unless m880?
+    return if ignorable_changes?
 
     ofile.write("#{@lines.join("\n")}\n\n")
   end

--- a/lib/authority_control_utilities/version.rb
+++ b/lib/authority_control_utilities/version.rb
@@ -1,3 +1,3 @@
 module AuthorityControl
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end

--- a/spec/changed_880_spec.rb
+++ b/spec/changed_880_spec.rb
@@ -4,11 +4,14 @@ require 'spec_helper'
 
 module AuthorityControl
   RSpec.describe Changed880 do
-    let (:c880) { Changed880.new(".b20857445, 38447\n") }
+    let(:c880) { Changed880.new(".b20857445, 38447\n") }
 
     context 'when containing an 880' do
-      let (:c880) do
+      let(:c880) do
         c = Changed880.new(".b20857445, 38447\r\n")
+        c.lines << '+830  0 $6880-04$aSilsilat al-ʻAnqāʼ ;$v10-11.'
+        c.lines << '-830  0 $6880-04$aSilsilat al-ʻAnqāʼ ;'\
+                   '$0http://id.loc.gov/authorities/names/no2002019550$v10-11.'
         c.lines << "-880\r\n".rstrip
         c
       end
@@ -20,11 +23,38 @@ module AuthorityControl
       end
 
       describe '#write' do
-        it "writes entry's lines and a blank line to output file for #script" do
-          i = StringIO.new
-          Changed880.outfiles[:other] = i
-          c880.write
-          expect(i.string).to eq(".b20857445, 38447\n-880\n\n")
+        context 'when substantive changes exist' do
+          it "writes entry's lines and a blank line to output file for #script" do
+            c880 = Changed880.new(".b20857445, 38447\r\n")
+            c880.lines << '+830  0 $6880-04$afoo'
+            c880.lines << '-830  0 $6880-04$abar'
+            c880.lines << "-880\r\n".rstrip
+
+            i = StringIO.new
+            Changed880.outfiles[:other] = i
+            c880.write
+            expect(c880.ignorable_changes?).to be false
+            expect(i.string).to eq(
+              ".b20857445, 38447\n+830  0 $6880-04$afoo\n"\
+              "-830  0 $6880-04$abar\n-880\n\n"
+            )
+          end
+        end
+
+        context 'when changes are ignorable' do
+          it 'writes nothing' do
+            c880 = Changed880.new(".b20857445, 38447\r\n")
+            c880.lines << '+830  0 $6880-04$aSilsilat al-ʻAnqāʼ ;$v10-11.'
+            c880.lines << '-830  0 $6880-04$aSilsilat al-ʻAnqāʼ ;'\
+                       '$0http://id.loc.gov/authorities/names/no2002019550$v10-11.'
+            c880.lines << "-880\r\n".rstrip
+
+            i = StringIO.new
+            Changed880.outfiles[:other] = i
+            c880.write
+            expect(c880.ignorable_changes?).to be true
+            expect(i.string).to be_empty
+          end
         end
       end
     end
@@ -46,25 +76,65 @@ module AuthorityControl
       end
     end
 
+    describe '#original_field' do
+      it 'returns the original non-vernacular field' do
+        c880.lines += ["+830  0 $afoo\n", "+830  0 $abar\n"]
+        expect(c880.original_field).to eq("+830  0 $afoo\n")
+      end
+    end
+
+    describe '#changed_field' do
+      it 'returns the changed non-vernacular field (post-changes)' do
+        c880.lines += ["+830  0 $afoo\n", "+830  0 $abar\n"]
+        expect(c880.changed_field).to eq("+830  0 $abar\n")
+      end
+    end
+
+    describe '#ignorable_changes?'  do
+      context 'when changes are only marcive adding a $0' do
+        it 'is true' do
+          c880.lines << '+830  0 $6880-04$aSilsilat al-ʻAnqāʼ ;$v10-11.'
+          c880.lines << '-830  0 $6880-04$aSilsilat al-ʻAnqāʼ ;'\
+                     '$0http://id.loc.gov/authorities/names/no2002019550$v10-11.'
+          c880.lines << "-880\r\n".rstrip
+          expect(c880.ignorable_changes?).to be true
+        end
+      end
+
+      context 'when changes are NOT only marcive adding a $0' do
+        it "is false" do
+          c880.lines << '+830  0 $6880-04$afoo'
+          c880.lines << '-830  0 $6880-04$abar'
+          c880.lines << "-880\r\n".rstrip
+          expect(c880.ignorable_changes?).to be false
+        end
+      end
+    end
+
     describe 'script' do
       it ' = :cjk when containing Han, Hangul characters' do
         c880.lines << "-880  0 $6830-06/$1$a華崗叢書"
+        expect(c880.script).to eq :cjk
       end
 
       it ' = :cjk when containing Katakana characters' do
         c880.lines << "-880  0 $6830-06/$1$aグ"
+        expect(c880.script).to eq :cjk
       end
 
       it ' else, = :cyrillic when containing Cyrillic characters' do
         c880.lines << "-880  0 $6830-06/$1$aСовременная"
+        expect(c880.script).to eq :cyrillic
       end
 
       it ' else, = :arabic when containing Arabic characters' do
         c880.lines << "-880  0 $6830-06/$1$aلة قض"
+        expect(c880.script).to eq :arabic
       end
 
       it 'else, = :other' do
         c880.lines << "-880  0 $6830-06/$1$afoo"
+        expect(c880.script).to eq :other
       end
     end
   end


### PR DESCRIPTION
- changed_880 report does not output entries where the only change is a $0 addition